### PR TITLE
created format time feature

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -231,7 +231,7 @@ export default {
       const t1 = performance.now()
       const time = t1 - t0
       this.format_time =
-        time <= 1000 ? `${time.toFixed(0)}ms` : `${(time / 1000).toFixed(1)}s`
+        time < 1100 ? `${time.toFixed(0)}ms` : `${(time / 1000).toFixed(1)}s`
       this.format_time_color =
         time < 1500 ? '#5ce60b' : time < 4000 ? '#ffcd00' : '#c83c1f'
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -230,7 +230,6 @@ export default {
 
       const t1 = performance.now()
       const time = t1 - t0
-      console.log(time)
       this.format_time =
         time <= 1000 ? `${time.toFixed(0)}ms` : `${(time / 1000).toFixed(1)}s`
       this.format_time_color =

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,6 +38,7 @@
       <div id="editor" />
     </div>
     <div class="action-buttons">
+      <p v-if="format_time && formatted" :style="{color:format_time_color}">{{ format_time }}</p>
       <button :class="{ 'formatted' : formatted === true }" @click="format(editor)">
         <svg style="margin-right: 10px;" width="16" height="14" xmlns="http://www.w3.org/2000/svg">
           <path
@@ -112,7 +113,9 @@ export default {
       info: false,
       editor: null,
       copied: false,
-      formatted: false
+      formatted: false,
+      format_time: 0,
+      format_time_color: '#5ce60b'
     }
   },
   async mounted() {
@@ -211,6 +214,8 @@ export default {
         return
       }
 
+      const t0 = performance.now()
+
       try {
         const formattedText = JSON.stringify(JSON.parse(text), null, 2)
         editor.setValue(formattedText)
@@ -222,10 +227,19 @@ export default {
         console.error('Error formatting JSON')
         console.error(err)
       }
+
+      const t1 = performance.now()
+      const time = t1 - t0
+      console.log(time)
+      this.format_time =
+        time <= 1000 ? `${time.toFixed(0)}ms` : `${(time / 1000).toFixed(1)}s`
+      this.format_time_color =
+        time < 1500 ? '#5ce60b' : time < 4000 ? '#ffcd00' : '#c83c1f'
+
       this.formatted = true
       setTimeout(() => {
         this.formatted = false
-      }, 1250)
+      }, time < 5000 ? 1250 : 3000)
     },
     saveJSON(text) {
       localStorage.setItem('jsoncache', text)

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,3 @@
-
 const express = require('express')
 const consola = require('consola')
 const { Nuxt, Builder } = require('nuxt')


### PR DESCRIPTION
format time is now displayed after formating:
- displayed in ms or seconds if time taken is greater than 1.1 second
- displayed for same time duration as the format button is in 'formatted' style
- variable text colour depending on time taken
- adjusted time for `this.formatted` to remain true for formattings that take longer than 5 seconds due to the app lagging sometimes on large inputs
<img width="321" alt="Screenshot 2019-11-03 at 17 09 55" src="https://user-images.githubusercontent.com/19176942/68089035-f0170e80-fe5c-11e9-955f-1f76c1a0d87f.png">
<img width="304" alt="Screenshot 2019-11-03 at 17 17 18" src="https://user-images.githubusercontent.com/19176942/68089153-e346ea80-fe5d-11e9-81c1-b4153dc748f9.png">
<img width="312" alt="Screenshot 2019-11-03 at 17 10 47" src="https://user-images.githubusercontent.com/19176942/68089036-f0170e80-fe5c-11e9-9aca-a12c09186133.png">